### PR TITLE
Fix NETSDK1071 warning

### DIFF
--- a/src/ItspServices.pServer.Abstraction/ItspServices.pServer.Abstraction.csproj
+++ b/src/ItspServices.pServer.Abstraction/ItspServices.pServer.Abstraction.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ItspServices.pServer.Persistence/ItspServices.pServer.Persistence.csproj
+++ b/src/ItspServices.pServer.Persistence/ItspServices.pServer.Persistence.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ItspServices.pServer/ItspServices.pServer.csproj
+++ b/src/ItspServices.pServer/ItspServices.pServer.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 

--- a/test/ItspServices.pServer.AuthorizationTest/ItspServices.pServer.AuthorizationTest.csproj
+++ b/test/ItspServices.pServer.AuthorizationTest/ItspServices.pServer.AuthorizationTest.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
 
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/ItspServices.pServer.RepositoryTest/ItspServices.pServer.RepositoryTest.csproj
+++ b/test/ItspServices.pServer.RepositoryTest/ItspServices.pServer.RepositoryTest.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
 
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/ItspServices.pServer.Test/ItspServices.pServer.Test.csproj
+++ b/test/ItspServices.pServer.Test/ItspServices.pServer.Test.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
+    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/ItspServices.pServer.Test/ItspServices.pServer.Test.csproj
+++ b/test/ItspServices.pServer.Test/ItspServices.pServer.Test.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.12.0" />


### PR DESCRIPTION
Fix the following warning:

```
warning NETSDK1071: A PackageReference to 'Microsoft.AspNetCore.All' specified a Version of `2.2.0`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs
```