### PR TITLE
Abstract Sign In/Out

### DIFF
--- a/ItspServices.pServer.sln
+++ b/ItspServices.pServer.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ItspServices.pServer.Server
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ItspServices.pServer.Persistence.Sqlite", "src\ItspServices.pServer.Persistence.Sqlite\ItspServices.pServer.Persistence.Sqlite.csproj", "{43E122D4-D477-4C99-93A3-4E265B7CEBC0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ItspServices.pServer.Core", "src\ItspServices.pServer.Core\ItspServices.pServer.Core.csproj", "{26A7D2B2-888C-4609-B249-1BC343AF87C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{43E122D4-D477-4C99-93A3-4E265B7CEBC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43E122D4-D477-4C99-93A3-4E265B7CEBC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43E122D4-D477-4C99-93A3-4E265B7CEBC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26A7D2B2-888C-4609-B249-1BC343AF87C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26A7D2B2-888C-4609-B249-1BC343AF87C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26A7D2B2-888C-4609-B249-1BC343AF87C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26A7D2B2-888C-4609-B249-1BC343AF87C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -54,6 +60,7 @@ Global
 		{DC421953-B5A8-4754-85CD-687796DE435B} = {2947A69F-1788-4262-9056-DAA917479403}
 		{1F29A51A-8B74-4522-9352-9E4A65F2BE39} = {8F4A9774-BDFD-4039-960D-D750115E290C}
 		{43E122D4-D477-4C99-93A3-4E265B7CEBC0} = {2947A69F-1788-4262-9056-DAA917479403}
+		{26A7D2B2-888C-4609-B249-1BC343AF87C7} = {2947A69F-1788-4262-9056-DAA917479403}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2B6BB9AC-5759-42D9-90F7-D507EE0F516A}

--- a/src/ItspServices.pServer.Abstraction/Models/UseCase/Request/Account/LoginRequest.cs
+++ b/src/ItspServices.pServer.Abstraction/Models/UseCase/Request/Account/LoginRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace ItspServices.pServer.Abstraction.Models.UseCase.Request.Account
+{
+    public class LoginRequest
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+
+        public LoginRequest(string username, string password)
+        {
+            Username = username;
+            Password = password;
+        }
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/Models/UseCase/Request/Account/LogoutRequest.cs
+++ b/src/ItspServices.pServer.Abstraction/Models/UseCase/Request/Account/LogoutRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace ItspServices.pServer.Abstraction.Models.UseCase.Request.Account
+{
+    public class LogoutRequest
+    {
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/Models/UseCase/Request/Account/RegisterRequest.cs
+++ b/src/ItspServices.pServer.Abstraction/Models/UseCase/Request/Account/RegisterRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace ItspServices.pServer.Abstraction.Models.UseCase.Request.Account
+{
+    public class RegisterRequest
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+
+        public RegisterRequest(string username, string password)
+        {
+            Username = username;
+            Password = password;
+        }
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/Models/UseCase/Response/UseCaseResponse.cs
+++ b/src/ItspServices.pServer.Abstraction/Models/UseCase/Response/UseCaseResponse.cs
@@ -1,0 +1,14 @@
+﻿namespace ItspServices.pServer.Abstraction.Models.UseCase.Response
+{
+    public class UseCaseResponse
+    {
+        public bool Success { get; set; }
+        public string Message { get; set; }
+
+        public UseCaseResponse(bool success, string message)
+        {
+            Success = success;
+            Message = message;
+        }
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/UseCase/Account/ILoginUserUseCase.cs
+++ b/src/ItspServices.pServer.Abstraction/UseCase/Account/ILoginUserUseCase.cs
@@ -1,0 +1,9 @@
+﻿using ItspServices.pServer.Abstraction.Models.UseCase.Request.Account;
+using ItspServices.pServer.Abstraction.Models.UseCase.Response;
+
+namespace ItspServices.pServer.Abstraction.UseCase.Account
+{
+    public interface ILoginUserUseCase : IUseCaseRequestHandler<LoginRequest, UseCaseResponse>
+    {
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/UseCase/Account/ILogoutUserUseCase.cs
+++ b/src/ItspServices.pServer.Abstraction/UseCase/Account/ILogoutUserUseCase.cs
@@ -1,0 +1,9 @@
+﻿using ItspServices.pServer.Abstraction.Models.UseCase.Request.Account;
+using ItspServices.pServer.Abstraction.Models.UseCase.Response;
+
+namespace ItspServices.pServer.Abstraction.UseCase.Account
+{
+    public interface ILogoutUserUseCase : IUseCaseRequestHandler<LogoutRequest, UseCaseResponse>
+    {
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/UseCase/Account/IRegisterUserUseCase.cs
+++ b/src/ItspServices.pServer.Abstraction/UseCase/Account/IRegisterUserUseCase.cs
@@ -1,0 +1,9 @@
+﻿using ItspServices.pServer.Abstraction.Models.UseCase.Request.Account;
+using ItspServices.pServer.Abstraction.Models.UseCase.Response;
+
+namespace ItspServices.pServer.Abstraction.UseCase.Account
+{
+    public interface IRegisterUserUseCase : IUseCaseRequestHandler<RegisterRequest, UseCaseResponse>
+    {
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/UseCase/Account/ISignInManager.cs
+++ b/src/ItspServices.pServer.Abstraction/UseCase/Account/ISignInManager.cs
@@ -5,5 +5,6 @@ namespace ItspServices.pServer.Abstraction.UseCase.Account
     public interface ISignInManager
     {
         Task<bool> PasswordSignInAsync(string username, string password);
+        Task<bool> SignOutAsync();
     }
 }

--- a/src/ItspServices.pServer.Abstraction/UseCase/Account/ISignInManager.cs
+++ b/src/ItspServices.pServer.Abstraction/UseCase/Account/ISignInManager.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace ItspServices.pServer.Abstraction.UseCase.Account
+{
+    public interface ISignInManager
+    {
+        Task<bool> PasswordSignInAsync(string username, string password);
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/UseCase/Account/IUserManager.cs
+++ b/src/ItspServices.pServer.Abstraction/UseCase/Account/IUserManager.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace ItspServices.pServer.Abstraction.UseCase.Account
+{
+    public interface IUserManager
+    {
+        Task<bool> CreateUserAsync(string username, string password);
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/UseCase/IOutputPort.cs
+++ b/src/ItspServices.pServer.Abstraction/UseCase/IOutputPort.cs
@@ -1,0 +1,7 @@
+﻿namespace ItspServices.pServer.Abstraction.UseCase
+{
+    public interface IOutputPort<in TUseCaseResponse>
+    {
+        void Handle(TUseCaseResponse response);
+    }
+}

--- a/src/ItspServices.pServer.Abstraction/UseCase/IUseCaseRequestHandler.cs
+++ b/src/ItspServices.pServer.Abstraction/UseCase/IUseCaseRequestHandler.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace ItspServices.pServer.Abstraction.UseCase
+{
+    public interface IUseCaseRequestHandler<in TUseCaseRequest, out TUseCaseResponse>
+    {
+        Task Handle(TUseCaseRequest request, IOutputPort<TUseCaseResponse> outputPort);
+    }
+}

--- a/src/ItspServices.pServer.Core/Account/LoginUserUseCase.cs
+++ b/src/ItspServices.pServer.Core/Account/LoginUserUseCase.cs
@@ -1,8 +1,6 @@
 ﻿using System.Threading.Tasks;
-using ItspServices.pServer.Abstraction.Models;
 using ItspServices.pServer.Abstraction.Models.UseCase.Request.Account;
 using ItspServices.pServer.Abstraction.Models.UseCase.Response;
-using ItspServices.pServer.Abstraction.Repository;
 using ItspServices.pServer.Abstraction.UseCase;
 using ItspServices.pServer.Abstraction.UseCase.Account;
 
@@ -10,21 +8,17 @@ namespace ItspServices.pServer.Core.Account
 {
     public class LoginUserUseCase : ILoginUserUseCase
     {
-        private readonly IUserRepository _userRepository;
+        private readonly ISignInManager _signInManager;
 
-        public LoginUserUseCase(IUserRepository userRepository)
+        public LoginUserUseCase(ISignInManager signInManager)
         {
-            _userRepository = userRepository;
+            _signInManager = signInManager;
         }
 
         public async Task Handle(LoginRequest request, IOutputPort<UseCaseResponse> outputPort)
         {
-            User user = _userRepository.GetUserByNormalizedName(request.Username.ToUpper());
-            if (user != null)
-            {
-                
-            }
-            outputPort.Handle(new UseCaseResponse(false, "Invalid username or password"));
+            bool success = await _signInManager.PasswordSignInAsync(request.Username, request.Password);
+            outputPort.Handle(new UseCaseResponse(success, success ? "" : "Invalid username or password"));
         }
     }
 }

--- a/src/ItspServices.pServer.Core/Account/LoginUserUseCase.cs
+++ b/src/ItspServices.pServer.Core/Account/LoginUserUseCase.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using ItspServices.pServer.Abstraction.Models;
+using ItspServices.pServer.Abstraction.Models.UseCase.Request.Account;
+using ItspServices.pServer.Abstraction.Models.UseCase.Response;
+using ItspServices.pServer.Abstraction.Repository;
+using ItspServices.pServer.Abstraction.UseCase;
+using ItspServices.pServer.Abstraction.UseCase.Account;
+
+namespace ItspServices.pServer.Core.Account
+{
+    public class LoginUserUseCase : ILoginUserUseCase
+    {
+        private readonly IUserRepository _userRepository;
+
+        public LoginUserUseCase(IUserRepository userRepository)
+        {
+            _userRepository = userRepository;
+        }
+
+        public async Task Handle(LoginRequest request, IOutputPort<UseCaseResponse> outputPort)
+        {
+            User user = _userRepository.GetUserByNormalizedName(request.Username.ToUpper());
+            if (user != null)
+            {
+                
+            }
+            outputPort.Handle(new UseCaseResponse(false, "Invalid username or password"));
+        }
+    }
+}

--- a/src/ItspServices.pServer.Core/Account/LogoutUserUseCase.cs
+++ b/src/ItspServices.pServer.Core/Account/LogoutUserUseCase.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using ItspServices.pServer.Abstraction.Models.UseCase.Request.Account;
+using ItspServices.pServer.Abstraction.Models.UseCase.Response;
+using ItspServices.pServer.Abstraction.UseCase;
+using ItspServices.pServer.Abstraction.UseCase.Account;
+
+namespace ItspServices.pServer.Core.Account
+{
+    public class LogoutUserUseCase : ILogoutUserUseCase
+    {
+        private readonly ISignInManager _signInManager;
+
+        public LogoutUserUseCase(ISignInManager signInManager)
+        {
+            _signInManager = signInManager;
+        }
+
+        public async Task Handle(LogoutRequest request, IOutputPort<UseCaseResponse> outputPort)
+        {
+            bool success = await _signInManager.SignOutAsync();
+            outputPort.Handle(new UseCaseResponse(success, ""));
+        }
+    }
+}

--- a/src/ItspServices.pServer.Core/Account/RegisterUserUseCase.cs
+++ b/src/ItspServices.pServer.Core/Account/RegisterUserUseCase.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using ItspServices.pServer.Abstraction.Models.UseCase.Request.Account;
+using ItspServices.pServer.Abstraction.Models.UseCase.Response;
+using ItspServices.pServer.Abstraction.UseCase;
+using ItspServices.pServer.Abstraction.UseCase.Account;
+
+namespace ItspServices.pServer.Core.Account
+{
+    public class RegisterUserUseCase : IRegisterUserUseCase
+    {
+        private readonly IUserManager _userManager;
+
+        public RegisterUserUseCase(IUserManager userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task Handle(RegisterRequest request, IOutputPort<UseCaseResponse> outputPort)
+        {
+            bool success = await _userManager.CreateUserAsync(request.Username, request.Password);
+            outputPort.Handle(new UseCaseResponse(success,
+                                                  success ? $"User {request.Username} created." : "User could not be created."));
+        }
+    }
+}

--- a/src/ItspServices.pServer.Core/ItspServices.pServer.Core.csproj
+++ b/src/ItspServices.pServer.Core/ItspServices.pServer.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ItspServices.pServer.Core/ItspServices.pServer.Core.csproj
+++ b/src/ItspServices.pServer.Core/ItspServices.pServer.Core.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ItspServices.pServer.Abstraction\ItspServices.pServer.Abstraction.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ItspServices.pServer.Core/ItspServices.pServer.Core.csproj
+++ b/src/ItspServices.pServer.Core/ItspServices.pServer.Core.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ItspServices.pServer.Abstraction\ItspServices.pServer.Abstraction.csproj" />
   </ItemGroup>
 

--- a/src/ItspServices.pServer.Core/UseCaseExtensions.cs
+++ b/src/ItspServices.pServer.Core/UseCaseExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using ItspServices.pServer.Abstraction.UseCase.Account;
+using ItspServices.pServer.Core.Account;
+
+namespace ItspServices.pServer.Core
+{
+    public static class UseCaseExtensions
+    {
+        public static void AddAuthUseCases(this IServiceCollection services)
+        {
+            services.AddTransient(typeof(ILoginUserUseCase), typeof(LoginUserUseCase));
+            services.AddTransient(typeof(ILogoutUserUseCase), typeof(LogoutUserUseCase));
+            services.AddTransient(typeof(IRegisterUserUseCase), typeof(RegisterUserUseCase));
+        }
+    }
+}

--- a/src/ItspServices.pServer/ItspServices.pServer.csproj
+++ b/src/ItspServices.pServer/ItspServices.pServer.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ItspServices.pServer.Abstraction\ItspServices.pServer.Abstraction.csproj" />
+    <ProjectReference Include="..\ItspServices.pServer.Core\ItspServices.pServer.Core.csproj" />
     <ProjectReference Include="..\ItspServices.pServer.Persistence.Sqlite\ItspServices.pServer.Persistence.Sqlite.csproj" />
   </ItemGroup>
 

--- a/src/ItspServices.pServer/Presenter/DefaultPresenter.cs
+++ b/src/ItspServices.pServer/Presenter/DefaultPresenter.cs
@@ -1,0 +1,17 @@
+﻿using ItspServices.pServer.Abstraction.Models.UseCase.Response;
+using ItspServices.pServer.Abstraction.UseCase;
+
+namespace ItspServices.pServer.Presenter
+{
+    public class DefaultPresenter : IOutputPort<UseCaseResponse>
+    {
+        public bool Success { get; private set; }
+        public string Message { get; private set; }
+
+        public void Handle(UseCaseResponse response)
+        {
+            Success = response.Success;
+            Message = response.Message;
+        }
+    }
+}

--- a/src/ItspServices.pServer/Startup.cs
+++ b/src/ItspServices.pServer/Startup.cs
@@ -12,6 +12,7 @@ using ItspServices.pServer.Persistence.Sqlite;
 using Microsoft.Data.Sqlite;
 using System.Collections.Generic;
 using ItspServices.pServer.Core;
+using ItspServices.pServer.Abstraction.UseCase.Account;
 
 namespace ItspServices.pServer
 {
@@ -49,6 +50,8 @@ namespace ItspServices.pServer
             services.AddTransient(typeof(IRoleStore<IdentityRole>), typeof(RoleStore));
 
             services.AddIdentity<User, IdentityRole>();
+            services.AddScoped(typeof(ISignInManager), typeof(SignInManagerAdapter));
+            services.AddScoped(typeof(IUserManager), typeof(UserManagerAdapter));
             services.AddAuthUseCases();
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);

--- a/src/ItspServices.pServer/Startup.cs
+++ b/src/ItspServices.pServer/Startup.cs
@@ -11,6 +11,7 @@ using ItspServices.pServer.Stores;
 using ItspServices.pServer.Persistence.Sqlite;
 using Microsoft.Data.Sqlite;
 using System.Collections.Generic;
+using ItspServices.pServer.Core;
 
 namespace ItspServices.pServer
 {
@@ -48,6 +49,7 @@ namespace ItspServices.pServer
             services.AddTransient(typeof(IRoleStore<IdentityRole>), typeof(RoleStore));
 
             services.AddIdentity<User, IdentityRole>();
+            services.AddAuthUseCases();
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }

--- a/src/ItspServices.pServer/Stores/SignInManagerAdapter.cs
+++ b/src/ItspServices.pServer/Stores/SignInManagerAdapter.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using ItspServices.pServer.Abstraction.Models;
+using ItspServices.pServer.Abstraction.UseCase.Account;
+
+namespace ItspServices.pServer.Stores
+{
+    public class SignInManagerAdapter : ISignInManager
+    {
+        private readonly SignInManager<User> _signInManager;
+
+        public SignInManagerAdapter(SignInManager<User> signInManager)
+        {
+            _signInManager = signInManager;
+        }
+
+        public async Task<bool> PasswordSignInAsync(string username, string password)
+        {
+            SignInResult result = await _signInManager.PasswordSignInAsync(username, password, false, false);
+            return result.Succeeded;
+        }
+
+        public async Task<bool> SignOutAsync()
+        {
+            await _signInManager.SignOutAsync();
+            return true;
+        }
+    }
+}

--- a/src/ItspServices.pServer/Stores/UserManagerAdapter.cs
+++ b/src/ItspServices.pServer/Stores/UserManagerAdapter.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using ItspServices.pServer.Abstraction.Models;
+using ItspServices.pServer.Abstraction.UseCase.Account;
+using Microsoft.AspNetCore.Identity;
+
+namespace ItspServices.pServer.Stores
+{
+    public class UserManagerAdapter : IUserManager
+    {
+        private readonly UserManager<User> _userManager;
+
+        public UserManagerAdapter(UserManager<User> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<bool> CreateUserAsync(string username, string password)
+        {
+            User user = new User()
+            {
+                UserName = username,
+                NormalizedUserName = username.ToUpper()
+            };
+            IdentityResult result = await _userManager.CreateAsync(user, password);
+            return result.Succeeded;
+        }
+    }
+}

--- a/test/ItspServices.pServer.ServerTest/CoreTests/AuthUseCaseTests.cs
+++ b/test/ItspServices.pServer.ServerTest/CoreTests/AuthUseCaseTests.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ItspServices.pServer.Abstraction.Models.UseCase.Request.Account;
+using ItspServices.pServer.Abstraction.Models.UseCase.Response;
+using ItspServices.pServer.Abstraction.Repository;
+using ItspServices.pServer.Abstraction.UseCase;
+using ItspServices.pServer.Abstraction.UseCase.Account;
+using ItspServices.pServer.Core.Account;
+using Moq;
+
+namespace ItspServices.pServer.ServerTest.CoreTests
+{
+    [TestClass]
+    public class AuthUseCaseTests
+    {
+
+        #region nested classes
+        class MockOutputPort : IOutputPort<UseCaseResponse>
+        {
+            public bool Success { get; private set; }
+            public string Message { get; private set; }
+
+            public void Handle(UseCaseResponse response)
+            {
+                Success = response.Success;
+                Message = response.Message;
+            }
+        }
+        #endregion
+
+        [TestMethod]
+        public void UserCanLogin_ShouldSucceed()
+        {
+            var userRepository = new Mock<IUserRepository>();
+
+            ILoginUserUseCase loginUseCase = new LoginUserUseCase(userRepository.Object);
+
+            MockOutputPort mockOutputPort = new MockOutputPort();
+
+            loginUseCase.Handle(new LoginRequest("fooUser", "barPassword"), mockOutputPort);
+
+            Assert.IsTrue(mockOutputPort.Success);
+        }
+    }
+}

--- a/test/ItspServices.pServer.ServerTest/CoreTests/AuthUseCaseTests.cs
+++ b/test/ItspServices.pServer.ServerTest/CoreTests/AuthUseCaseTests.cs
@@ -56,5 +56,26 @@ namespace ItspServices.pServer.ServerTest.CoreTests
 
             Assert.IsFalse(mockOutputPort.Success);
         }
+
+        [TestMethod]
+        public async Task UserCanLogout_ShouldSucceed()
+        {
+            var signInManager = new Mock<ISignInManager>();
+            signInManager.Setup(x => x.PasswordSignInAsync(It.IsAny<string>(),
+                                                           It.IsAny<string>()))
+                .Returns(Task.FromResult(true));
+            signInManager.Setup(x => x.SignOutAsync())
+                .Returns(Task.FromResult(true));
+            MockOutputPort mockOutputPort = new MockOutputPort();
+
+            ILoginUserUseCase loginUseCase = new LoginUserUseCase(signInManager.Object);
+            ILogoutUserUseCase logoutUseCase = new LogoutUserUseCase(signInManager.Object);
+
+            await loginUseCase.Handle(new LoginRequest("fooUser", "barPassword"), mockOutputPort);
+            Assert.IsTrue(mockOutputPort.Success);
+
+            await logoutUseCase.Handle(new LogoutRequest(), mockOutputPort);
+            Assert.IsTrue(mockOutputPort.Success);
+        }
     }
 }

--- a/test/ItspServices.pServer.ServerTest/CoreTests/AuthUseCaseTests.cs
+++ b/test/ItspServices.pServer.ServerTest/CoreTests/AuthUseCaseTests.cs
@@ -77,5 +77,35 @@ namespace ItspServices.pServer.ServerTest.CoreTests
             await logoutUseCase.Handle(new LogoutRequest(), mockOutputPort);
             Assert.IsTrue(mockOutputPort.Success);
         }
+
+        [TestMethod]
+        public async Task RegisterNewUser_ShouldSucceed()
+        {
+            var userManager = new Mock<IUserManager>();
+            userManager.Setup(x => x.CreateUserAsync(It.Is<string>(s => s == "fooUser"),
+                                                     It.Is<string>(s => s == "barPassword")))
+                .Returns(Task.FromResult(true));
+            MockOutputPort mockOutputPort = new MockOutputPort();
+
+            IRegisterUserUseCase registerUseCase = new RegisterUserUseCase(userManager.Object);
+            await registerUseCase.Handle(new RegisterRequest("fooUser", "barPassword"), mockOutputPort);
+
+            Assert.IsTrue(mockOutputPort.Success);
+        }
+
+        [TestMethod]
+        public async Task RegisterNewUser_UserAlreadyExists_ShouldFail()
+        {
+            var userManager = new Mock<IUserManager>();
+            userManager.Setup(x => x.CreateUserAsync(It.IsAny<string>(),
+                                                     It.IsAny<string>()))
+                .Returns(Task.FromResult(false));
+            MockOutputPort mockOutputPort = new MockOutputPort();
+
+            IRegisterUserUseCase registerUseCase = new RegisterUserUseCase(userManager.Object);
+            await registerUseCase.Handle(new RegisterRequest("fooUser", "barPassword"), mockOutputPort);
+
+            Assert.IsFalse(mockOutputPort.Success);
+        }
     }
 }

--- a/test/ItspServices.pServer.ServerTest/ItspServices.pServer.ServerTest.csproj
+++ b/test/ItspServices.pServer.ServerTest/ItspServices.pServer.ServerTest.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ItspServices.pServer.Abstraction\ItspServices.pServer.Abstraction.csproj" />
+    <ProjectReference Include="..\..\src\ItspServices.pServer.Core\ItspServices.pServer.Core.csproj" />
     <ProjectReference Include="..\..\src\ItspServices.pServer.Persistence.Sqlite\ItspServices.pServer.Persistence.Sqlite.csproj" />
     <ProjectReference Include="..\..\src\ItspServices.pServer\ItspServices.pServer.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Move sign in/out logic out of account controller and into smaller use cases. The use-cases use interfaces for sign in and user management which can be injected depending on the needed implementation. Provided implementation for Microsoft.AspNetCore.Identity.

## Changes
- Add use case Interfaces
- Implement use cases
- Remove SignInManager from AccountController
- Add unit tests for use cases